### PR TITLE
docs: document native multi-label task type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ evaluator.add_data(data)
 Define what and how to evaluate using EvalTask:
 
 ```python
-from meta_evaluator.eval_task import EvalTask
+from meta_evaluator.eval_task import EvalTask, MultiLabelSchema
 
 task = EvalTask(
     task_schemas={
-        "rejection": ["rejection", "not rejection"],  # Classification (required by default)
+        "rejection": ["rejection", "not rejection"],  # Single-select classification (required by default)
+        "harm_types": MultiLabelSchema(                # Multi-label: pick several at once
+            outcomes=["hateful", "insults", "sexual"]
+        ),
         "explanation": None,  # Free-form text (not required by default)
     },
     # required_tasks not specified - only classification tasks required by default
@@ -91,6 +94,8 @@ task = EvalTask(
 )
 evaluator.add_eval_task(task)
 ```
+
+A task schema can be a single-select list (`["rejection", "not rejection"]`), a free-form field (`None`), or a **multi-label** field via `MultiLabelSchema` when more than one label can apply at once. See the [task-definition guide](docs/guides/evaltask.md#multi-label-tasks-pick-several) for details.
 
 ### 4. Collect Human Annotations
 Collect human ground truth using the built-in Streamlit interface:
@@ -246,8 +251,8 @@ For detailed data format requirements and examples, see the [Results Guide](docs
 MetaEvaluator supports comprehensive alignment metrics for evaluating judge performance:
 
 ### Classification Metrics
-- **Accuracy/F1/Recall/Precision**: Classification metrics between judge and human labels
-- **Cohen's Kappa**: Inter-rater agreement accounting for chance agreement  
+- **Accuracy/F1/Recall/Precision**: Classification metrics between judge and human labels. For multi-label tasks, use `average="macro"` (or `"samples"`).
+- **Cohen's Kappa**: Inter-rater agreement accounting for chance agreement. *Not supported for multi-label tasks* — use `ClassificationScorer` or `AltTestScorer` instead.
 - **Alt-Test**: Statistical significance testing with leave-one-annotator-out methodology
 
 ### Text Similarity Metrics  

--- a/docs/annotation_guide/annotation.md
+++ b/docs/annotation_guide/annotation.md
@@ -91,6 +91,16 @@ task = EvalTask(
 - Uses annotator name and session time to differentiate annotations
 - Auto-saves when required fields are filled; resumes from last incomplete sample on reload
 
+### Field types in the interface
+
+Each task schema renders as a different widget:
+
+- **Single-select** (a `list[str]` schema like `["excellent", "good", "fair", "poor"]`) renders as a **radio group** — exactly one choice.
+- **Free-form** (a `None` schema) renders as a **text box**.
+- **Multi-label** (a [`MultiLabelSchema`](../guides/evaltask.md#multi-label-tasks-pick-several) schema) renders as a **checkbox group** — one checkbox per declared outcome, so the annotator can select several at once.
+
+For a multi-label task, the number-key shortcut **toggles** the corresponding slot on or off (it does not replace the selection, unlike single-select). Selecting nothing is recorded as an all-`"FALSE"` vector — "nothing applies" is a fully defined answer, never an empty or missing value. See the [task-definition guide](../guides/evaltask.md#multi-label-tasks-pick-several) for the schema details.
+
 **The annotation platform (Web):**
 <figure markdown="span">
   ![Simple Annotation Interface](../assets/simple_annotation_interface.png)

--- a/docs/guides/judges_run.md
+++ b/docs/guides/judges_run.md
@@ -2,6 +2,9 @@
 
 Execute your configured LLM judges to evaluate your dataset.
 
+!!! note "Multi-label tasks"
+    For a [multi-label task](evaltask.md#multi-label-tasks-pick-several), the judge emits the **full ordered vector** (every slot explicit). Multi-label is supported only by the `structured` and `instructor` answering methods — a direct `answering_method="xml"` raises an error, and `xml` is excluded from the `structured_outputs_fallback` sequence (its scalar-only path cannot carry the ordered vector).
+
 ## Quick Setup
 
 === "Async (Recommended)"
@@ -161,7 +164,19 @@ The aggregation strategy depends on the task type:
     The answer was concise and accurate...
     ```
 
-Both task types are supported simultaneously — a judge with a mixed schema (some classification, some free-form tasks) will apply the appropriate strategy per task.
+=== "Multi-label tasks"
+
+    A [multi-label task](evaltask.md#multi-label-tasks-pick-several) is aggregated **independently per slot**. Each slot uses the same majority-vote rule as classification (most votes wins, ties broken by first occurrence), so the aggregated result is still a full ordered vector.
+
+    ```
+             slot:  hateful   insults   sexual
+    Run 1:          hateful   FALSE     sexual
+    Run 2:          hateful   insults   FALSE
+    Run 3:          hateful   FALSE     FALSE
+    majority:       hateful   FALSE     FALSE
+    ```
+
+All task types are supported simultaneously — a judge with a mixed schema (classification, free-form, and multi-label tasks) applies the appropriate strategy per task.
 
 !!! note
     With `consistency > 1`, token counts and call durations in the results are **summed** across all runs.

--- a/docs/guides/results.md
+++ b/docs/guides/results.md
@@ -100,6 +100,25 @@ task = EvalTask(
 # - "explanation" (with free-form text values)
 ```
 
+### Multi-label Task Columns
+
+A [multi-label task](evaltask.md#multi-label-tasks-pick-several) (declared with `MultiLabelSchema`) stores its outcome as a **fixed-length ordered vector** (`list[str]`) in a single column — one slot per declared outcome, holding either that outcome's name (selected) or the sentinel `"FALSE"` (not selected). Slot order matches the schema's `outcomes` order and is preserved on load.
+
+```python linenums="1"
+task_schemas={
+    "harm_types": MultiLabelSchema(outcomes=["hateful", "insults", "sexual", "violent"]),
+}
+# A row that is hateful and sexual (but not insulting or violent) is stored as:
+# ["hateful", "FALSE", "sexual", "FALSE"]
+```
+
+**Serialization by format:**
+
+- **Parquet** and **JSON** store the list natively — no encoding needed.
+- **CSV** cannot hold a native list column, so each multi-label cell is **JSON-encoded** on write (e.g. `"[""hateful"", ""FALSE"", ""sexual"", ""FALSE""]"`) and **JSON-decoded on load**. The load path identifies which columns to decode from the persisted results `task_schemas` (the `MultiLabelSchema` marks them), so standalone results loading works without the original `EvalTask` object.
+
+When authoring an **external** multi-label CSV by hand, JSON-encode each multi-label cell the same way so it decodes back to the ordered vector.
+
 ### Complete Example
 
 See `examples/rejection/run_scoring_only_async.py` in the [GitHub Repository](https://github.com/govtech-responsibleai/meta-evaluator/blob/main/examples/rejection/run_scoring_only_async.py) for a complete example that:

--- a/docs/guides/scoring.md
+++ b/docs/guides/scoring.md
@@ -19,7 +19,7 @@ Configure and use alignment metrics to compare judge evaluations with human anno
             MetricConfig(
                 scorer=ClassificationScorer(metric="accuracy"),
                 task_names=["rejection"],
-                task_strategy="single", # One of 'single', 'multilabel', or 'multitask'
+                task_strategy="single", # 'single' or 'multitask' (aggregation across task_names)
                 annotator_aggregation="individual_average",  # Default
                 display_name="rejection_accuracy",  # Optional: custom column name
             ),
@@ -44,38 +44,28 @@ Configure and use alignment metrics to compare judge evaluations with human anno
     cohens_kappa_scorer = CohensKappaScorer()
     text_similarity_scorer = TextSimilarityScorer()
     
+    # Assumes a native multi-label task "harm_types" declared with MultiLabelSchema
     config = MetricsConfig(
         metrics=[
+            # Native multi-label task: one column, scored with task_strategy="single"
             MetricConfig(
-                scorer=alt_test_scorer,
-                task_names=[
-                    "hateful",
-                    "insults",
-                    "sexual",
-                    "physical_violence",
-                    "self_harm",
-                    "all_other_misconduct",
-                ],
-                task_strategy="multilabel",
-                annotator_aggregation="individual_average",
-            ),
-            MetricConfig(
-                scorer=cohens_kappa_scorer,
-                task_names=["hateful"],
+                scorer=ClassificationScorer(metric="f1", average="macro"),
+                task_names=["harm_types"],
                 task_strategy="single",
                 annotator_aggregation="individual_average",
             ),
+            # AltTest scores the native name vector unchanged
+            MetricConfig(
+                scorer=alt_test_scorer,
+                task_names=["harm_types"],
+                task_strategy="single",
+                annotator_aggregation="individual_average",
+            ),
+            # A separate single-select task
             MetricConfig(
                 scorer=cohens_kappa_scorer,
-                task_names=[
-                    "hateful",
-                    "insults",
-                    "sexual",
-                    "physical_violence",
-                    "self_harm",
-                    "all_other_misconduct",
-                ],
-                task_strategy="multitask",
+                task_names=["rejection"],
+                task_strategy="single",
                 annotator_aggregation="individual_average",
             ),
             MetricConfig(
@@ -224,7 +214,7 @@ Configure and use alignment metrics to compare judge evaluations with human anno
     {
       "judge_id": "anthropic_claude_3_5_haiku_judge",
       "scorer_name": "alt_test",
-      "task_strategy": "multilabel", 
+      "task_strategy": "single", 
       "task_name": "rejection",
       "scores": {
         "winning_rate": {
@@ -352,11 +342,19 @@ Configure and use alignment metrics to compare judge evaluations with human anno
 ## Arguments
 ### Task Configuration Types (`task_strategy`)
 
-The `task_strategy` parameter defines how tasks are processed and must be one of: `"single"`, `"multitask"`, or `"multilabel"`.
+`task_strategy` controls **how a scorer's results are aggregated across the `task_names` in one `MetricConfig`** — it is about aggregation, *not* about the shape of any individual task's value:
+
+- **`"single"`**: score **one** task on its own.
+- **`"multitask"`**: score **several** tasks with the same scorer, then average their scores into one result.
+
+This is independent of whether a task's value is single-select, free-form, or multi-label. In particular, a native [multi-label task](evaltask.md#multi-label-tasks-pick-several) is a single column and is scored with `task_strategy="single"` — its "pick several" nature lives in the `EvalTask` schema, not in `task_strategy`. See [Scoring multi-label tasks](#scoring-multi-label-tasks) below.
 
 !!! important "Task Count Requirements"
     - **`"single"`**: Use only when `task_names` contains **exactly 1 task**
-    - **`"multitask"`** and **`"multilabel"`**: Use only when `task_names` contains **2 or more tasks**
+    - **`"multitask"`**: Use only when `task_names` contains **2 or more tasks**
+
+!!! warning "`task_strategy="multilabel"` is deprecated"
+    A third value, `task_strategy="multilabel"`, still exists: it melts **multiple single-select task columns** into one aligned vector at scoring time. It is **deprecated** — declare a native [`MultiLabelSchema`](evaltask.md#multi-label-tasks-pick-several) task instead (scored with `task_strategy="single"`). It still functions in the current version, but will be removed in a future release. See [The legacy `multilabel` strategy](#the-legacy-multilabel-strategy-deprecated).
 
 === "Single Label (Single Task)"
     
@@ -405,60 +403,71 @@ The `task_strategy` parameter defines how tasks are processed and must be one of
         - **Result**: Aggregated score across all tasks
         - For different scorers on different tasks, create separate `MetricConfig` entries
 
-=== "Multi-Label (Combined Classification)"
-    
-    Treat multiple classification tasks as a single multi-label problem:
-
-    ```python linenums="1" hl_lines="8 9"
-    # Multi-label classification (AltTestScorer only)
-    alt_test_scorer = AltTestScorer()
-
-    config = MetricsConfig(
-        metrics=[
-            MetricConfig(
-                scorer=alt_test_scorer,
-                task_names=["hateful", "violent", "sexual"],  # Combined as multi-label
-                task_strategy="multilabel",  # Required: "multilabel" for combined tasks
-                annotator_aggregation="individual_average",
-            ),
-        ]
-    )
-    ```
-
-
-    !!! note "Multi-label Behavior"
-        - **Required**: 2 or more tasks in `task_names` list
-        - Each instance can have multiple labels: `["hateful", "violent"]`, and these will be passed as 1 input into the Scorer.
-        - Calculation of metric depends on the Scorer. For instance AltTestScorer uses Jaccard similarity for comparison, and ClassificationScorer with metric="accuracy" uses exact match.
-
-
 **Example with different scorers per task:**
-```python linenums="1" hl_lines="7 13 19"
+```python linenums="1" hl_lines="7 13"
 config = MetricsConfig(
     metrics=[
-        # Accuracy for single classification tasks
+        # Accuracy for a single classification task
         MetricConfig(
             scorer=ClassificationScorer(metric="accuracy"),
             task_names=["helpful"],
             task_strategy="single",
             annotator_aggregation="majority_vote",
         ),
-        # Accuracy for multitask classification tasks
+        # Same scorer applied across several tasks, then averaged
         MetricConfig(
             scorer=ClassificationScorer(metric="accuracy"),
             task_names=["helpful", "harmless", "honest"],
             task_strategy="multitask",
             annotator_aggregation="individual_average",
         ),
-        # Text similarity for text tasks, all tasks combined into one multilabel
+    ]
+)
+```
+
+### Scoring multi-label tasks
+
+A native [multi-label task](evaltask.md#multi-label-tasks-pick-several) (declared with `MultiLabelSchema`) is **one column**, so it is scored with `task_strategy="single"`. The recommended scorer is `ClassificationScorer`:
+
+```python linenums="1" hl_lines="7 8"
+from meta_evaluator.scores.metrics import ClassificationScorer
+
+config = MetricsConfig(
+    metrics=[
         MetricConfig(
-            scorer=TextSimilarityScorer(),
-            task_names=["explanation", "reasoning"],
-            task_strategy="multilabel",
-            annotator_aggregation="majority_vote",
+            scorer=ClassificationScorer(metric="f1", average="macro"),  # or average="samples"
+            task_names=["harm_types"],   # ONE native multi-label task
+            task_strategy="single",
+            annotator_aggregation="individual_average",
         ),
     ]
 )
+```
+
+- The name-vector is **binarized positionally** (slot `i` → `1` if it holds outcome `i`'s name, `0` if `"FALSE"`) into a per-slot indicator vector, then scored.
+- For F1/precision/recall, `ClassificationScorer.average` **must** be `"macro"` (per-label, recommended) or `"samples"` (per-item overlap). The global default `"binary"` is rejected with a clear error. Accuracy ignores `average`. A mixed single-class + multi-label `multitask` config must use `"macro"`.
+- **`AltTestScorer`** scores the native **name** vector unchanged (it is *not* binarized; its Jaccard similarity auto-routes on list-valued labels).
+- **`CohensKappaScorer` does not support multi-label tasks** and raises a clear error — κ has no valid averaging axis over a sparse multi-label vector. Use `ClassificationScorer` or `AltTestScorer` instead.
+
+### The legacy `multilabel` strategy (deprecated)
+
+!!! warning "Deprecated"
+    `task_strategy="multilabel"` melts **N separate single-select task columns** into one aligned vector at scoring time. It predates the native multi-label task type and is **deprecated**. Prefer declaring a single [`MultiLabelSchema`](evaltask.md#multi-label-tasks-pick-several) task and scoring it with `task_strategy="single"` (above). The legacy strategy still functions in the current version but will be removed in a future release.
+
+Migration — replace N single-select tasks combined by the melt:
+
+```python
+# Before (deprecated): six single-select tasks melted at scoring time
+# task_schemas: {"hateful": ["FALSE","hateful"], "insults": ["FALSE","insults"], ...}
+MetricConfig(scorer=alt_test_scorer,
+             task_names=["hateful", "insults", "sexual"],
+             task_strategy="multilabel")
+
+# After: one native multi-label task, scored as a single column
+# task_schemas: {"harm_types": MultiLabelSchema(outcomes=["hateful","insults","sexual"])}
+MetricConfig(scorer=alt_test_scorer,
+             task_names=["harm_types"],
+             task_strategy="single")
 ```
 
 ### Annotator Aggregation (`annotator_aggregation`)
@@ -530,7 +539,7 @@ config = MetricsConfig(
 
 | Metric | individual_average | majority_vote |
 |--------|-------------------|---------------|
-| **ClassificationScorer** | :material-check: | :material-check: Per-position majority for multilabel, alphabetical tie-breaking |
+| **ClassificationScorer** | :material-check: | :material-check: Per-position majority for multi-label vectors, alphabetical tie-breaking |
 | **TextSimilarityScorer** | :material-check: | :material-check: Best-match approach: highest similarity human per sample |
 | **SemanticSimilarityScorer** | :material-check: | :material-check: Best-match approach: highest similarity human per sample |
 | **CohensKappaScorer** | :material-check: | :material-close: Logs warning, falls back to individual_average (agreement metric) |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -76,6 +76,9 @@ evaluator.add_data(data)
 evaluator.launch_annotator(port=8000)
 ```
 
+!!! tip "Need to pick several labels at once?"
+    Besides single-select (`list[str]`) and free-form (`None`) tasks, MetaEvaluator supports a native **multi-label** task type for fields where more than one label can apply at once (e.g. a response that is both `hateful` and `sexual`). Declare it with `MultiLabelSchema` and it carries through annotation, judging, storage, and scoring as one field. See the [task-definition guide](guides/evaltask.md#multi-label-tasks-pick-several).
+
 
 ### Step 3: Create Judge Configuration
 

--- a/openspec/changes/document-multilabel-tasks/.openspec.yaml
+++ b/openspec/changes/document-multilabel-tasks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/document-multilabel-tasks/design.md
+++ b/openspec/changes/document-multilabel-tasks/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The native multi-label task type (`MultiLabelSchema`) shipped in v0.3.0. Behavior
+is authoritative in the merged `multilabel-task-type` change and in the source. Two
+guides already document it well (`docs/guides/evaltask.md`, and the native section of
+`docs/guides/scoring.md`); the remaining guides do not mention it. This change is
+purely additive documentation — no code moves.
+
+The one non-trivial issue is a **terminology collision**: `scoring.md` predates the
+native type and uses "multi-label" to mean `task_strategy="multilabel"` — the legacy
+melt that combines *N separate single-select task columns* into one aligned vector at
+scoring time. The native `MultiLabelSchema` is a *single* task/column scored via
+`task_strategy="single"`. Both are legitimate and coexist in the current code; a reader
+must not confuse them.
+
+The intended long-term direction is that `task_strategy` means only **how a scorer's
+results are aggregated across the `task_names` in one `MetricConfig`** — decoupled from
+whether any individual task's *value* is multi-label. Under that framing the legacy
+`"multilabel"` melt no longer has a place (a native `MultiLabelSchema` task carries its
+own vector shape and is scored with `task_strategy="single"`). This change documents
+that direction and **deprecates** the legacy melt in prose; it does **not** remove
+`TaskAggregationMode.MULTILABEL` from code. Actual removal is a separate breaking change
+(6 source + 3 test files) targeting a future major version.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every guide a reader would follow for annotation, judging, results, and scoring
+  mentions the native multi-label type where it is relevant, and links to the
+  authoritative detail in `evaltask.md`.
+- The legacy-melt vs. native-task distinction is stated explicitly wherever both
+  could be read as "multi-label".
+- Examples in docs match the shipped API (`MultiLabelSchema(outcomes=[...])`, the
+  `"FALSE"` sentinel, `average="macro"`).
+
+**Non-Goals:**
+- No source, API, or behavior changes.
+- No rewrite of the well-covered `evaltask.md` multi-label section (single source of
+  truth; other guides link to it rather than duplicate).
+- No new scorer, no change to the legacy `task_strategy="multilabel"` behavior — only
+  clarifying prose.
+
+## Decisions
+
+- **`evaltask.md` stays the single source of truth for the task definition.** Other
+  guides give a short, self-contained note for their own concern (a checkbox in
+  annotation, a `list[str]` column in results, an ordered vector in judging) and link
+  back, rather than re-explaining the sentinel/slot contract in five places.
+  *Alternative considered:* duplicate the full explanation per guide — rejected as a
+  drift hazard.
+- **`task_strategy` is documented as an aggregation choice only.** Reframe the guide so
+  `task_strategy` answers "how are this MetricConfig's task scores combined" (`single` =
+  one task; `multitask` = several tasks scored then averaged), not "what shape is the
+  task value". The native multi-label task's value shape lives in the `EvalTask` schema,
+  and it is scored with `task_strategy="single"`. *Alternative:* keep the old framing and
+  only add a disambiguation note — rejected; the framing itself is the root confusion.
+- **Deprecate the legacy melt in prose, do not remove or rename it.** `scoring.md` keeps
+  the `task_strategy="multilabel"` docs but marks them deprecated with a migration note
+  (declare a `MultiLabelSchema` task instead). *Alternatives:* (a) remove the strategy
+  now — rejected, that is a breaking code change out of scope here; (b) rename it —
+  rejected, it would diverge from the shipped API. Removal is deferred to a separate
+  breaking change, which is **not filed yet**, so the note names no target version.
+- **Stop presenting the legacy melt as a recommended path.** Beyond the one deprecated
+  reference tab, the native `MultiLabelSchema` task is the recommended way to score
+  multi-label; incidental `task_strategy="multilabel"` examples elsewhere in the guide
+  (e.g. the `TextSimilarityScorer` snippet) are rewritten off the melt or annotated as
+  deprecated so a reader skimming for examples is not steered onto it.
+- **Verify by mkdocs build**, since there is no test surface for docs. Broken internal
+  links or malformed code fences are the realistic failure modes.
+
+## Risks / Trade-offs
+
+- [Docs drift from code as the feature evolves] → Keep detail centralized in
+  `evaltask.md`; other guides link, minimizing places to update.
+- [Terminology callout adds cognitive load in `scoring.md`] → Keep it a short admonition
+  with one line each for legacy vs. native, plus a link.
+- [Examples silently go stale] → Mirror the exact API already shown in `evaltask.md`
+  and confirm imports resolve.
+
+## Open Questions
+
+- None blocking. A follow-up breaking change to remove `TaskAggregationMode.MULTILABEL`
+  is anticipated but is deliberately **not filed yet**; the deprecation note therefore
+  refers to "a future release" without naming a version.

--- a/openspec/changes/document-multilabel-tasks/proposal.md
+++ b/openspec/changes/document-multilabel-tasks/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The native multi-label task type shipped in v0.3.0 (`MultiLabelSchema`, checkbox
+annotation, positional binarize scoring). Its user-facing documentation is
+uneven: `docs/guides/evaltask.md` and `docs/guides/scoring.md` cover it, but the
+results, judge-running, annotation, and tutorial guides do not mention it at all —
+so a reader following those guides hits list-valued outcome columns, a checkbox
+widget, and `ClassificationScorer(average="macro")` with no explanation. The
+`scoring.md` guide also overloads the word "multi-label": it still frames
+`task_strategy="multilabel"` (the legacy N-column melt) as *the* multi-label story,
+which now collides with the native task type and misleads readers.
+
+## What Changes
+
+- **Annotation guide** (`annotation_guide/annotation.md`): document the checkbox-group
+  field for multi-label tasks — how it renders, that number-key shortcuts toggle a
+  slot (rather than replace), and that "nothing applies" is an all-`"FALSE"` vector.
+- **Results guide** (`docs/guides/results.md`): explain that a multi-label task's
+  outcome column holds a fixed-length ordered vector (`list[str]`), how it survives
+  parquet/JSON round-trips natively, and that CSV JSON-encodes each cell (decoded on
+  load via the persisted schema).
+- **Judge-run guide** (`docs/guides/judges_run.md`): note that multi-label tasks emit
+  the full ordered vector and are limited to `structured`/`instructor` answering
+  methods (XML rejected, excluded from fallback), and how consistency runs aggregate
+  per slot.
+- **Scoring guide** (`docs/guides/scoring.md`): reframe `task_strategy` as purely an
+  **aggregation** choice — how a scorer's results are combined *across the task_names
+  in one MetricConfig* (`single` = one task, `multitask` = several tasks scored then
+  averaged) — decoupled from the *task's own value shape*. Mark the legacy
+  `task_strategy="multilabel"` melt as **deprecated** and add a migration note steering
+  readers to declare a native `MultiLabelSchema` task (scored with
+  `task_strategy="single"`) instead of melting N single-select tasks. The strategy is
+  not removed from code by this change; removal is deferred to a later, breaking change.
+- **Tutorial** (`docs/tutorial.md`): add a short pointer to the multi-label task type
+  so first-time readers know it exists and where the detail lives.
+- **Root README** (`README.md`): the "Define Task" example shows only single-select and
+  free-form schemas, and "Available Metrics" lists Cohen's Kappa without noting it is
+  unsupported for multi-label. Add a brief multi-label mention (with the
+  `MultiLabelSchema` option and a link to the guide) so the first-read entry point is
+  not silent on the feature.
+- No changes to the two guides that already cover it well
+  (`evaltask.md`, and the `scoring.md` native section) beyond the disambiguation callout.
+
+This is a **documentation-only** change: no source, API, or behavior changes.
+
+## Capabilities
+
+### New Capabilities
+- `multilabel-docs`: user-facing documentation coverage for the native multi-label
+  task type across the annotation, results, judge-run, scoring, and tutorial guides,
+  including disambiguation from the legacy `task_strategy="multilabel"` melt.
+
+### Modified Capabilities
+<!-- No existing OpenSpec specs capture doc behavior; this is a new docs capability. -->
+
+## Impact
+
+- `docs/guides/results.md`, `docs/guides/judges_run.md`, `docs/guides/scoring.md`,
+  `docs/tutorial.md`, `docs/annotation_guide/annotation.md`, `README.md`.
+- No code, dependency, or public-API impact. mkdocs build must still succeed.
+- Aligns with the already-merged `multilabel-task-type` change (source of truth for
+  behavior); this change only closes documentation gaps it left.

--- a/openspec/changes/document-multilabel-tasks/specs/multilabel-docs/spec.md
+++ b/openspec/changes/document-multilabel-tasks/specs/multilabel-docs/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Annotation guide documents the multi-label checkbox field
+
+The annotation guide (`docs/annotation_guide/annotation.md`) SHALL describe how a
+multi-label task appears and behaves in the annotation interface.
+
+#### Scenario: Checkbox rendering is documented
+
+- **WHEN** a reader consults the annotation guide about task field types
+- **THEN** it states that a `MultiLabelSchema` task renders as a checkbox group (one
+  checkbox per declared outcome), distinct from the single-select radio group
+
+#### Scenario: Slot toggle and empty selection are documented
+
+- **WHEN** a reader looks for multi-label interaction details
+- **THEN** the guide states that the number-key shortcut toggles a single slot (rather
+  than replacing the selection) and that selecting nothing is recorded as an
+  all-`"FALSE"` vector, never an empty or missing value
+
+### Requirement: Results guide documents multi-label outcome columns
+
+The results guide (`docs/guides/results.md`) SHALL describe the storage shape and
+round-trip behavior of multi-label outcome values.
+
+#### Scenario: Vector-valued column is documented
+
+- **WHEN** a reader consults the results guide about outcome columns
+- **THEN** it states that a multi-label task's outcome column holds a fixed-length
+  ordered vector (`list[str]`) with slot order preserved
+
+#### Scenario: Serialization formats are documented
+
+- **WHEN** a reader looks for how multi-label results persist
+- **THEN** the guide states that parquet and JSON store the list natively while CSV
+  JSON-encodes each cell on write and decodes it on load using the persisted schema
+
+### Requirement: Judge-run guide documents multi-label emission and constraints
+
+The judge-run guide (`docs/guides/judges_run.md`) SHALL describe how judges produce
+multi-label outputs and the associated constraints.
+
+#### Scenario: Answering-method restriction is documented
+
+- **WHEN** a reader consults the judge-run guide for multi-label tasks
+- **THEN** it states that judges emit the full ordered vector and that only
+  `structured` and `instructor` answering methods are supported, with `xml` rejected
+  and excluded from the fallback sequence
+
+#### Scenario: Consistency aggregation is documented
+
+- **WHEN** a reader looks for how consistency runs handle multi-label tasks
+- **THEN** the guide states that aggregation happens independently per slot (most votes
+  wins, ties by first occurrence)
+
+### Requirement: Scoring guide frames task_strategy as an aggregation choice
+
+The scoring guide (`docs/guides/scoring.md`) SHALL present `task_strategy` as a choice
+about how a scorer's results are aggregated across the `task_names` in one
+`MetricConfig`, decoupled from any individual task's value shape.
+
+#### Scenario: Aggregation framing is explicit
+
+- **WHEN** a reader consults the scoring guide about `task_strategy`
+- **THEN** it states that `task_strategy="single"` scores one task and
+  `task_strategy="multitask"` scores several tasks then averages their results, and that
+  this is independent of whether a task's value is single-select, free-form, or
+  multi-label
+
+#### Scenario: Native multi-label uses single aggregation
+
+- **WHEN** a reader wants to score a native `MultiLabelSchema` task
+- **THEN** the guide states it is scored with `task_strategy="single"` (one task column)
+  using `ClassificationScorer` with `average="macro"` (or `"samples"`), that the default
+  `"binary"` is rejected, that `AltTestScorer` scores the native name vector unchanged,
+  and that `CohensKappaScorer` raises for multi-label tasks
+
+### Requirement: Scoring guide deprecates the legacy multilabel strategy
+
+The scoring guide (`docs/guides/scoring.md`) SHALL mark `task_strategy="multilabel"` as
+deprecated and steer readers to the native multi-label task type.
+
+#### Scenario: Deprecation and migration are documented
+
+- **WHEN** a reader encounters `task_strategy="multilabel"` in the scoring guide
+- **THEN** it is marked deprecated with a migration note explaining that N single-select
+  tasks combined by the melt should instead be declared as one `MultiLabelSchema` task
+  scored with `task_strategy="single"`
+
+#### Scenario: Deprecation does not claim removal
+
+- **WHEN** the deprecation note is read
+- **THEN** it makes clear the strategy still functions in the current version and that
+  removal is planned for a future release, without asserting it is already removed or
+  naming a specific target version
+
+#### Scenario: Legacy melt is not presented as a recommended path
+
+- **WHEN** a reader skims the scoring guide for multi-label examples
+- **THEN** the native `MultiLabelSchema` task is the recommended approach, and any
+  remaining `task_strategy="multilabel"` example outside the deprecated reference is
+  rewritten off the melt or explicitly annotated as deprecated
+
+### Requirement: Tutorial points to the multi-label task type
+
+The tutorial (`docs/tutorial.md`) SHALL make first-time readers aware that the native
+multi-label task type exists and where to find its detailed documentation.
+
+#### Scenario: Discoverability pointer exists
+
+- **WHEN** a first-time reader follows the tutorial
+- **THEN** it mentions the multi-label task type and links to the task-definition guide
+  for details
+
+### Requirement: Root README mentions the multi-label task type
+
+The root `README.md` SHALL make the multi-label task type visible at the primary
+getting-started entry point.
+
+#### Scenario: Define-task section mentions multi-label
+
+- **WHEN** a reader reaches the "Define Task" section of the README
+- **THEN** it notes that a task may be multi-label via `MultiLabelSchema(outcomes=[...])`
+  (in addition to single-select and free-form) and links to `docs/guides/evaltask.md`
+
+#### Scenario: Metrics section notes the kappa limitation
+
+- **WHEN** a reader reads the README "Available Metrics" section
+- **THEN** it notes that Cohen's Kappa is not supported for multi-label tasks and points
+  to `ClassificationScorer`/`AltTestScorer` for them
+
+### Requirement: Documentation examples match the shipped API
+
+All documentation examples added by this change SHALL use the shipped public API and
+build cleanly.
+
+#### Scenario: Examples use current API and mkdocs builds
+
+- **WHEN** the documentation is built
+- **THEN** multi-label examples use `MultiLabelSchema(outcomes=[...])`, the reserved
+  `"FALSE"` sentinel, and `average="macro"`, and the mkdocs build succeeds with no
+  broken internal links

--- a/openspec/changes/document-multilabel-tasks/tasks.md
+++ b/openspec/changes/document-multilabel-tasks/tasks.md
@@ -1,0 +1,60 @@
+## 1. Annotation guide
+
+- [x] 1.1 In `docs/annotation_guide/annotation.md`, add a short "Multi-label tasks"
+  note: renders as a checkbox group (one box per outcome), distinct from radio
+  single-select; link to `guides/evaltask.md` for the schema detail.
+- [x] 1.2 Document that the number-key shortcut toggles one slot (does not replace the
+  selection) and that selecting nothing is stored as an all-`"FALSE"` vector.
+
+## 2. Results guide
+
+- [x] 2.1 In `docs/guides/results.md`, document that a multi-label outcome column holds
+  a fixed-length ordered `list[str]` vector with slot order preserved.
+- [x] 2.2 Document serialization: parquet/JSON store the list natively; CSV JSON-encodes
+  each cell on write and decodes on load via the persisted schema.
+
+## 3. Judge-run guide
+
+- [x] 3.1 In `docs/guides/judges_run.md`, document that multi-label judges emit the full
+  ordered vector and support only `structured`/`instructor` (XML rejected and excluded
+  from fallback).
+- [x] 3.2 Document that consistency runs aggregate independently per slot (most votes
+  wins, ties by first occurrence).
+
+## 4. Scoring guide: reframe task_strategy + deprecate legacy melt
+
+- [x] 4.1 In `docs/guides/scoring.md` "Task Configuration Types", reframe `task_strategy`
+  as an **aggregation** choice: `single` scores one task, `multitask` scores several
+  tasks then averages — independent of a task's value shape. Adjust the intro/`!!!`
+  boxes accordingly.
+- [x] 4.2 Mark the "Multi-Label (Combined Classification)" tab and `task_strategy="multilabel"`
+  as **deprecated** with a migration note: declare a native `MultiLabelSchema` task
+  (scored with `task_strategy="single"`) instead of melting N single-select tasks. State
+  it still works today and removal is planned for a future release (do not claim it is
+  already removed).
+- [x] 4.3 Confirm/complete the native scoring path text: `ClassificationScorer` with
+  `average="macro"` (or `"samples"`), `"binary"` rejected, `AltTestScorer` on the native
+  name vector, `CohensKappaScorer` raises for multi-label. Link to `evaltask.md`.
+- [x] 4.4 Sweep `scoring.md` for the stray `task_strategy="multilabel"` examples (e.g. the
+  `TextSimilarityScorer` "all tasks combined into one multilabel" snippet) and update or
+  annotate them so they no longer present the melt as the recommended path.
+
+## 5. Tutorial pointer
+
+- [x] 5.1 In `docs/tutorial.md`, add a brief mention of the multi-label task type with a
+  link to `guides/evaltask.md`.
+
+## 6. Root README
+
+- [x] 6.1 In `README.md` "Define Task" (~line 75), note the multi-label option via
+  `MultiLabelSchema(outcomes=[...])` alongside single-select and free-form, and link to
+  `docs/guides/evaltask.md`.
+- [x] 6.2 In `README.md` "Available Metrics" (~line 244), note that Cohen's Kappa is
+  unsupported for multi-label tasks and point to `ClassificationScorer`/`AltTestScorer`.
+
+## 7. Verify
+
+- [x] 7.1 Ensure all added examples use `MultiLabelSchema(outcomes=[...])`, the `"FALSE"`
+  sentinel, and `average="macro"`, matching the shipped API.
+- [x] 7.2 Build the docs (`uv run mkdocs build`) and confirm no errors and no broken
+  internal links.


### PR DESCRIPTION
## Summary

Closes the documentation gaps left by the native multi-label task type shipped in v0.3.0 (#47). Docs-only — no code changes.

## What changed

- **Annotation guide**: checkbox-group field for `MultiLabelSchema` tasks, number-key toggles a slot, empty selection = all-`"FALSE"` vector.
- **Results guide**: multi-label outcome column holds a `list[str]` vector with preserved slot order; parquet/JSON store natively, CSV JSON-encodes/decodes.
- **Judge-run guide**: judges emit the full ordered vector, `structured`/`instructor` only (XML rejected, excluded from fallback), consistency aggregates per slot.
- **Scoring guide**: reframe `task_strategy` as an *aggregation* choice (`single`/`multitask`); add a native multi-label scoring section (`ClassificationScorer` with `average="macro"`/`"samples"`, `AltTest` on the name vector, Cohen's Kappa unsupported); **deprecate** the legacy `task_strategy="multilabel"` melt with a migration note (still works, removal planned for a future release — no version named).
- **Tutorial + README**: point readers to the multi-label task type; note kappa is unsupported for multi-label.
- Includes the `document-multilabel-tasks` OpenSpec change (proposal, design, spec, tasks).

## Verification

- `mkdocs build --strict` passes (exit 0); all internal anchors resolve.
- Multi-label API examples confirmed to construct against the shipped API.