### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/src/meta_evaluator/__init__.py
+++ b/src/meta_evaluator/__init__.py
@@ -12,7 +12,7 @@ from .meta_evaluator import MetaEvaluator
 
 beartype_this_package()
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 __all__ = [
     "MetaEvaluator",


### PR DESCRIPTION
## Why

The `v0.3.0` release failed to publish to PyPI:

```
400 File already exists ('meta_evaluator-0.2.2-py3-none-any.whl', ...)
```

The release built **0.2.2** artifacts because `src/meta_evaluator/__init__.py` (which hatchling reads via `[tool.hatch.version]`) still said `0.2.2` — the version bump was missed when the multi-label feature (#47) merged. PyPI already has 0.2.2, so the upload was rejected.

## What

- Bump `__version__` from `0.2.2` → `0.3.0`.

Verified: hatch now reads `0.3.0`, and PyPI currently has only `0.1.0 / 0.2.0 / 0.2.1 / 0.2.2`, so `0.3.0` will upload cleanly.

## Follow-up (manual, after merge)

The existing `v0.3.0` tag/release points at the old commit (0.2.2 code). After this merges, the `v0.3.0` GitHub release + tag must be **deleted and re-created** on the new commit so the publish workflow builds and uploads 0.3.0.