### PR TITLE
feat(annotator): center sample card and add draggable rail resize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,22 @@ Ensure your last command is always `uv tool run ruff format .`
 - Optional dependency groups: `docs` (mkdocs), `ui` (streamlit), `all` (everything). Core deps include matplotlib.
 - Publishing is automated via `.github/workflows/publish.yml` on GitHub release creation using trusted publishing (OIDC).
 
+## Annotator Frontend
+
+The annotator UI is a React + Vite + Tailwind app living in `src/meta_evaluator/annotator/frontend`. It is served to annotators as a pre-built bundle embedded in the Python package (the launcher serves `frontend/dist`).
+
+All frontend commands are run from inside `src/meta_evaluator/annotator/frontend`:
+```bash
+npm run lint    # oxlint
+npm run test    # vitest run
+npm run build   # tsc -b && vite build — regenerates frontend/dist
+npm run dev      # local dev server for manual verification
+```
+
+After any change to frontend source:
+1. Run `npm run lint` and `npm run test`; fix issues in the files you touched.
+2. Run `npm run build` to confirm the bundle compiles. **Do NOT commit `frontend/dist` — it is gitignored.** The bundle is rebuilt from source by CI (`ci.yml`) and the publish workflow (`publish.yml`) via `npm run build`, and hatchling includes it as a build artifact (`[tool.hatch.build.targets.*].artifacts`). So a UI change ships as source; the embedded bundle is regenerated at build/publish time.
+
 ## Additional Reminders (VERY IMPORTANT!)
 
 - If you have any questions or doubts about the instructions, ask me before you begin. 

--- a/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/design.md
+++ b/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The annotation view (`AnnotationView.tsx`) is a two-column flex layout inside a full-height flex-column shell:
+
+```
+h-screen flex flex-col
+├── Navigation bar (sticky)
+├── "Save & Next" hint bar
+└── flex-1 flex md:flex-row          ← the two-column row
+    ├── LEFT: flex-1, overflow-y-auto
+    │     └── div.max-w-4xl          ← card wrapper (SampleDisplay)
+    └── RIGHT: md:w-[26rem] shrink-0  ← annotation rail (TaskPanel)
+          bg var(--annotation-rail), md:border-l
+```
+
+Two ergonomics issues:
+1. The card wrapper caps width at `max-w-4xl` but has no horizontal auto-margin, so it hugs the left edge and leaves dead space on its right.
+2. The rail is a hardcoded `md:w-[26rem]`, so annotators cannot widen it for long option labels or narrow it to read more of the sample.
+
+The layout stacks vertically below the `md` breakpoint (`flex-col md:flex-row`), where a horizontal drag handle makes no sense.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Center the capped-width card within the left column.
+- Allow drag-to-resize of the rail via the vertical divider, with a visible `col-resize` handle.
+- Clamp rail width to a sane min/max so neither column collapses.
+- Keep resize desktop-only; keep the mobile stacked layout unchanged.
+
+**Non-Goals:**
+- Persisting the chosen width across reloads (explicitly out of scope; width resets to default).
+- Introducing a resizable-panels library or any new dependency.
+- Centering the card relative to the whole viewport (centering is within the left column only).
+- Making the left column independently resizable — it always fills remaining space.
+
+## Decisions
+
+### Decision 1: Center the card with `mx-auto`
+
+Add `mx-auto` to the `max-w-4xl` wrapper on line 47. `max-w-4xl` already caps the width; `mx-auto` supplies the equal left/right margins that center it within the `flex-1` column.
+
+- **Why not `justify-center` on the column?** The column is `overflow-y-auto` and also positions other absolutely/relatively placed content; `mx-auto` on the block is the least invasive and the idiomatic Tailwind approach already used elsewhere in the codebase.
+
+### Decision 2: Hand-rolled drag resize with React state
+
+Replace the static `md:w-[26rem]` with a state-driven width applied via inline style on the rail, plus a thin drag handle on the divider.
+
+- Introduce `const [railWidth, setRailWidth] = useState(DEFAULT_RAIL_WIDTH)` where `DEFAULT_RAIL_WIDTH = 416` (26rem in px).
+- Apply the width with an inline `style={{ width: railWidth }}` on the rail (guarded to desktop — see Decision 4), keeping `shrink-0` so the left column yields space.
+- Add a handle element positioned on the shared border (`cursor-col-resize`, a few px wide, full height). On `mouseDown`, attach `mousemove`/`mouseup` listeners to `window`; on each `mousemove`, compute the new width from the viewport right edge minus `event.clientX` and call `setRailWidth(clamp(...))`; on `mouseup`, detach.
+- Use a `useRef`/`useEffect` cleanup so listeners are always removed (including on unmount mid-drag) and add `user-select: none` on the body during drag to prevent text selection.
+
+- **Why hand-rolled over `react-resizable-panels`?** This is a single split; the library would add a dependency and force both columns into its `Panel`/`PanelResizeHandle` wrappers. Hand-rolled is ~30–50 lines, matches the existing bespoke component style, and keeps the bundle lean.
+
+### Decision 3: Clamp width to min/max
+
+Clamp `railWidth` between `MIN_RAIL_WIDTH` (e.g. 320px — enough for the widest option labels) and `MAX_RAIL_WIDTH` (e.g. `min(640, window.innerWidth * 0.6)` — leaves the left column usable). Exact constants are an implementation detail; the requirement is only that both columns stay usable.
+
+### Decision 4: Desktop-only via breakpoint guard
+
+The layout is `flex-col md:flex-row`. The inline width and the handle must only apply on the `md:` (horizontal) layout so the mobile stacked layout keeps full-width columns.
+
+- Render the handle only in the horizontal layout (e.g. an `md:block hidden` handle), and apply the inline width in a way that does not override the mobile full-width (`w-full`) behavior — e.g. gate the inline style on a matchMedia/`md` check, or scope it so mobile `w-full` wins. Tailwind's responsive classes cannot read a JS number, so the inline style is applied only when the desktop layout is active.
+
+## Risks / Trade-offs
+
+- **Inline width vs. Tailwind responsive classes** → Inline styles always win over classes, which could break the mobile `w-full` layout if applied unconditionally. Mitigation: only apply the inline width when the desktop (`md`) layout is active (matchMedia or equivalent guard), verified against the stacked mobile view.
+- **Drag listeners leaking / text selection during drag** → Mitigation: attach listeners on `mouseDown`, always detach on `mouseUp` and on unmount via `useEffect` cleanup; toggle `user-select: none` during drag.
+- **No persistence surprises the user** → Accepted trade-off per scope decision; width resets to 26rem each load. Revisit later if annotators ask for it (would be a small `localStorage` follow-up).
+- **Fast drags outrunning `mousemove`** → Using `window`-level listeners (not the handle element) keeps tracking even when the cursor leaves the thin handle, avoiding stalls.

--- a/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/proposal.md
+++ b/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+In the annotator UI, the prompt/response card is left-aligned in the left column, leaving a large empty gap on its right and making the layout feel unbalanced. Separately, the annotation rail is a fixed width, so annotators working with long option labels or wanting more room to read the sample cannot adjust the split. Both are small layout ergonomics issues that make daily annotation work less comfortable.
+
+## What Changes
+
+- Center the prompt/response card horizontally within the left column (currently pinned to the left edge).
+- Make the annotation rail (right column) resizable by dragging the vertical divider between the two columns, with a visible `col-resize` handle.
+- Clamp the rail width between a sensible minimum and maximum so neither column can collapse or dominate the viewport.
+- Resize is desktop-only (the layout already stacks vertically on mobile); width resets to the default on each page load (no persistence).
+
+## Capabilities
+
+### New Capabilities
+- `annotator-layout`: Horizontal layout behavior of the annotation view — card centering within the left column and drag-to-resize of the annotation rail, including min/max clamping and desktop-only applicability.
+
+### Modified Capabilities
+<!-- None: no existing specs define annotation view layout behavior. -->
+
+## Impact
+
+- **Code**: `src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx` (layout markup, resize state, drag handlers, resize handle element).
+- **Tests**: Frontend component tests under `src/meta_evaluator/annotator/frontend/src/__tests__/` may add coverage for the resize handle presence/behavior.
+- **Build artifact**: The embedded frontend bundle (`dist/`) is regenerated and re-embedded for the Python package.
+- **Dependencies**: None — resize is hand-rolled with React state and mouse listeners; no new npm packages.
+- **No changes** to Python API, data schemas, or annotation persistence.

--- a/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/specs/annotator-layout/spec.md
+++ b/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/specs/annotator-layout/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Prompt/response card centering
+
+The annotation view SHALL horizontally center the prompt/response card within the left column, while retaining the existing maximum width constraint on the card.
+
+#### Scenario: Card centered when left column is wider than the card
+
+- **WHEN** the annotation view is rendered on a viewport where the left column is wider than the card's maximum width
+- **THEN** the card SHALL be horizontally centered within the left column with equal left and right margins
+
+#### Scenario: Card respects maximum width
+
+- **WHEN** the left column is wider than the card's maximum width
+- **THEN** the card SHALL NOT exceed its maximum width and SHALL remain centered rather than stretching to fill the column
+
+### Requirement: Resizable annotation rail
+
+The annotation view SHALL let the user resize the annotation rail (right column) by dragging the vertical divider between the left column and the rail. A visible resize handle SHALL be presented on the divider with a `col-resize` cursor affordance.
+
+#### Scenario: Dragging the handle changes the rail width
+
+- **WHEN** the user presses on the resize handle and drags horizontally
+- **THEN** the annotation rail width SHALL update to follow the horizontal cursor position and the left column SHALL adjust to fill the remaining space
+
+#### Scenario: Rail width is clamped within bounds
+
+- **WHEN** the user drags the handle beyond the allowed range
+- **THEN** the rail width SHALL be clamped to a minimum and maximum bound so that neither the rail nor the left column can collapse or dominate the viewport
+
+#### Scenario: Width resets on reload
+
+- **WHEN** the user reloads the page after resizing the rail
+- **THEN** the rail width SHALL return to its default width (no persistence across reloads)
+
+### Requirement: Desktop-only resize
+
+The resize handle SHALL only be active on the horizontal (desktop) layout. On narrow viewports where the layout stacks vertically, the resize handle SHALL NOT be presented and the columns SHALL retain their stacked full-width behavior.
+
+#### Scenario: Handle hidden on stacked layout
+
+- **WHEN** the viewport is narrow enough that the left column and annotation rail stack vertically
+- **THEN** the resize handle SHALL NOT be shown and dragging SHALL have no effect on layout

--- a/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/tasks.md
+++ b/openspec/changes/archive/2026-07-02-annotator-layout-tweaks/tasks.md
@@ -1,0 +1,27 @@
+## 1. Center the prompt/response card
+
+- [x] 1.1 In `AnnotationView.tsx`, add `mx-auto` to the `max-w-4xl` card wrapper (the div around `SampleDisplay`)
+- [x] 1.2 Verify in the dev server that the card centers within the left column at desktop width and still respects its max width
+
+## 2. Resizable rail state and handlers
+
+- [x] 2.1 In `AnnotationView.tsx`, add width constants (`DEFAULT_RAIL_WIDTH = 416`, `MIN_RAIL_WIDTH`, `MAX_RAIL_WIDTH`) and `const [railWidth, setRailWidth] = useState(DEFAULT_RAIL_WIDTH)`
+- [x] 2.2 Add a `clamp` helper (or inline clamp) that bounds the new width between min and max (max may be relative to `window.innerWidth`)
+- [x] 2.3 Implement drag handlers: `onMouseDown` on the handle attaches `mousemove`/`mouseup` listeners on `window`; `mousemove` computes width from `window.innerWidth - event.clientX` and calls `setRailWidth(clamp(...))`; `mouseup` detaches
+- [x] 2.4 Toggle `user-select: none` on the document body during an active drag and restore it on `mouseup`
+- [x] 2.5 Add a `useEffect` cleanup that removes any attached listeners on unmount (guard against mid-drag unmount)
+
+## 3. Resize handle and desktop-only layout wiring
+
+- [x] 3.1 Add a thin vertical resize handle element on the divider between the left column and the rail, with `cursor-col-resize` and a subtle visible affordance; render it only on the horizontal layout (`hidden md:block` or equivalent)
+- [x] 3.2 Apply `railWidth` to the rail via inline `style={{ width }}` only when the desktop (`md`) layout is active, so the mobile `w-full` stacked layout is not overridden (use a matchMedia/`md` guard)
+- [x] 3.3 Confirm the rail keeps `shrink-0` and the left column keeps `flex-1` so the left column absorbs the width change
+
+## 4. Verification
+
+- [x] 4.1 Manually verify in dev: drag widens/narrows the rail, clamps at min and max, text does not get selected during drag, and fast drags off the handle still track
+- [x] 4.2 Verify mobile/stacked layout (below `md`) shows no handle and columns remain full-width
+- [x] 4.3 Verify width resets to default after a page reload (no persistence)
+- [x] 4.4 Add/adjust a component test under `src/__tests__/` covering the handle's presence on desktop layout (and absence on stacked layout if feasible)
+- [x] 4.5 Run frontend lint (`npm run lint`) and tests (`npm run test`) in the frontend dir; fix any issues
+- [x] 4.6 Rebuild the embedded bundle (`npm run build`) so `frontend/dist` reflects the changes

--- a/openspec/specs/annotator-layout/spec.md
+++ b/openspec/specs/annotator-layout/spec.md
@@ -1,0 +1,49 @@
+# annotator-layout Specification
+
+## Purpose
+
+Define the layout behavior of the annotation view, including how the prompt/response card is positioned, how the annotation rail can be resized, and how these behaviors respond to viewport size.
+
+## Requirements
+
+### Requirement: Prompt/response card centering
+
+The annotation view SHALL horizontally center the prompt/response card within the left column, while retaining the existing maximum width constraint on the card.
+
+#### Scenario: Card centered when left column is wider than the card
+
+- **WHEN** the annotation view is rendered on a viewport where the left column is wider than the card's maximum width
+- **THEN** the card SHALL be horizontally centered within the left column with equal left and right margins
+
+#### Scenario: Card respects maximum width
+
+- **WHEN** the left column is wider than the card's maximum width
+- **THEN** the card SHALL NOT exceed its maximum width and SHALL remain centered rather than stretching to fill the column
+
+### Requirement: Resizable annotation rail
+
+The annotation view SHALL let the user resize the annotation rail (right column) by dragging the vertical divider between the left column and the rail. A visible resize handle SHALL be presented on the divider with a `col-resize` cursor affordance.
+
+#### Scenario: Dragging the handle changes the rail width
+
+- **WHEN** the user presses on the resize handle and drags horizontally
+- **THEN** the annotation rail width SHALL update to follow the horizontal cursor position and the left column SHALL adjust to fill the remaining space
+
+#### Scenario: Rail width is clamped within bounds
+
+- **WHEN** the user drags the handle beyond the allowed range
+- **THEN** the rail width SHALL be clamped to a minimum and maximum bound so that neither the rail nor the left column can collapse or dominate the viewport
+
+#### Scenario: Width resets on reload
+
+- **WHEN** the user reloads the page after resizing the rail
+- **THEN** the rail width SHALL return to its default width (no persistence across reloads)
+
+### Requirement: Desktop-only resize
+
+The resize handle SHALL only be active on the horizontal (desktop) layout. On narrow viewports where the layout stacks vertically, the resize handle SHALL NOT be presented and the columns SHALL retain their stacked full-width behavior.
+
+#### Scenario: Handle hidden on stacked layout
+
+- **WHEN** the viewport is narrow enough that the left column and annotation rail stack vertically
+- **THEN** the resize handle SHALL NOT be shown and dragging SHALL have no effect on layout

--- a/src/meta_evaluator/__init__.py
+++ b/src/meta_evaluator/__init__.py
@@ -12,7 +12,7 @@ from .meta_evaluator import MetaEvaluator
 
 beartype_this_package()
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "MetaEvaluator",

--- a/src/meta_evaluator/annotator/frontend/src/__tests__/AnnotationView.test.tsx
+++ b/src/meta_evaluator/annotator/frontend/src/__tests__/AnnotationView.test.tsx
@@ -1,0 +1,85 @@
+import { AnnotationView } from "@/components/AnnotationView";
+import type { Progress, Sample, TaskConfig } from "@/lib/api";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const taskConfig: TaskConfig = {
+  task_schemas: {
+    sentiment: ["positive", "negative", "neutral"],
+  },
+  prompt_columns: ["text"],
+  response_columns: ["response"],
+  annotation_prompt: "Evaluate this:",
+  required_tasks: ["sentiment"],
+};
+
+const sample: Sample = {
+  index: 0,
+  total: 3,
+  sample_id: "s1",
+  prompt_data: { text: "Hello" },
+  response_data: { response: "Hi" },
+  previous_annotation: null,
+};
+
+const progress: Progress = {
+  run_id: "run_1",
+  annotated_count: 0,
+  total_samples: 3,
+  incomplete_indices: [0, 1, 2],
+};
+
+/** Install a matchMedia mock that reports the given desktop state. */
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function renderView() {
+  return render(
+    <AnnotationView
+      taskConfig={taskConfig}
+      sample={sample}
+      progress={progress}
+      onSubmit={vi.fn()}
+      onNavigate={vi.fn()}
+      onExport={vi.fn()}
+    />,
+  );
+}
+
+describe("AnnotationView layout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a vertical resize handle", () => {
+    mockMatchMedia(true);
+    renderView();
+    const handle = screen.getByRole("separator");
+    expect(handle).toHaveAttribute("aria-orientation", "vertical");
+    expect(handle).toHaveClass("cursor-col-resize");
+  });
+
+  it("applies an inline rail width on the desktop layout", () => {
+    mockMatchMedia(true);
+    renderView();
+    const rail = screen.getByRole("separator").nextElementSibling as HTMLElement;
+    expect(rail.style.width).toBe("416px");
+  });
+
+  it("does not apply an inline rail width on the stacked layout", () => {
+    mockMatchMedia(false);
+    renderView();
+    const rail = screen.getByRole("separator").nextElementSibling as HTMLElement;
+    expect(rail.style.width).toBe("");
+  });
+});

--- a/src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx
+++ b/src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import type { OutcomeValue, Progress, Sample, TaskConfig } from "@/lib/api";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigation } from "./Navigation";
 import { SampleDisplay } from "./SampleDisplay";
 import { TaskPanel } from "./TaskPanel";
@@ -13,6 +14,24 @@ interface Props {
   onExport: () => void;
 }
 
+/** Default annotation rail width in px (26rem). */
+const DEFAULT_RAIL_WIDTH = 416;
+/** Narrowest the rail may be dragged — keeps long option labels readable. */
+const MIN_RAIL_WIDTH = 320;
+/** Widest the rail may be dragged, absolutely and relative to the viewport. */
+const MAX_RAIL_WIDTH = 640;
+/** Tailwind `md` breakpoint — below this the layout stacks vertically. */
+const DESKTOP_MEDIA_QUERY = "(min-width: 768px)";
+
+function clampRailWidth(width: number): number {
+  const viewportMax =
+    typeof window !== "undefined"
+      ? Math.min(MAX_RAIL_WIDTH, window.innerWidth * 0.6)
+      : MAX_RAIL_WIDTH;
+  const upper = Math.max(MIN_RAIL_WIDTH, viewportMax);
+  return Math.min(Math.max(width, MIN_RAIL_WIDTH), upper);
+}
+
 export function AnnotationView({
   taskConfig,
   sample,
@@ -23,6 +42,48 @@ export function AnnotationView({
 }: Props) {
   const canExport =
     progress && progress.annotated_count === progress.total_samples;
+
+  const [railWidth, setRailWidth] = useState(DEFAULT_RAIL_WIDTH);
+  // Whether the horizontal (desktop) layout is active. The inline rail width
+  // must only apply here so the mobile stacked `w-full` layout is preserved.
+  const [isDesktop, setIsDesktop] = useState(false);
+  const cleanupDragRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const update = () => setIsDesktop(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  // Detach any active drag listeners on unmount (guards mid-drag unmount).
+  useEffect(() => {
+    return () => {
+      cleanupDragRef.current?.();
+    };
+  }, []);
+
+  const handleResizeStart = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      setRailWidth(clampRailWidth(window.innerWidth - moveEvent.clientX));
+    };
+
+    const stopDrag = () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", stopDrag);
+      document.body.style.userSelect = "";
+      cleanupDragRef.current = null;
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", stopDrag);
+    document.body.style.userSelect = "none";
+    cleanupDragRef.current = stopDrag;
+  }, []);
 
   return (
     <div className="h-screen flex flex-col bg-background overflow-hidden">
@@ -44,12 +105,22 @@ export function AnnotationView({
 
       <div className="relative flex-1 flex min-h-0 flex-col md:flex-row overflow-hidden">
         <div className="relative flex-1 min-h-0 px-4 py-5 md:px-8 md:py-7 overflow-y-auto scroll-slim">
-          <div className="max-w-4xl">
+          <div className="max-w-4xl mx-auto">
             <SampleDisplay sample={sample} taskConfig={taskConfig} />
           </div>
         </div>
 
-        <div className="relative w-full md:w-[26rem] shrink-0 px-4 py-5 md:px-5 md:py-7 overflow-y-auto scroll-slim bg-[var(--annotation-rail)] border-t md:border-t-0 md:border-l border-[var(--annotation-rail-border)]">
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          onMouseDown={handleResizeStart}
+          className="hidden md:block w-1 shrink-0 cursor-col-resize bg-[var(--annotation-rail-border)] hover:bg-primary/40 transition-colors"
+        />
+
+        <div
+          className="relative w-full md:w-[26rem] shrink-0 px-4 py-5 md:px-5 md:py-7 overflow-y-auto scroll-slim bg-[var(--annotation-rail)] border-t md:border-t-0 border-[var(--annotation-rail-border)]"
+          style={isDesktop ? { width: railWidth } : undefined}
+        >
           <TaskPanel
             taskConfig={taskConfig}
             sample={sample}


### PR DESCRIPTION
## Summary

Two annotator-UI ergonomics tweaks:

1. **Center the prompt/response card** within the left column. It was pinned to the left edge (`max-w-4xl` with no auto-margin); now `mx-auto` centers it while keeping the max-width cap.
2. **Draggable rail resize.** The annotation rail was a fixed `26rem`. You can now drag the vertical divider to resize it.

## How it works

- Hand-rolled resize (no new dependency): `useState` for the width + `window` `mousemove`/`mouseup` listeners attached on `mousedown`.
- Width is clamped between `320px` and `min(640, 60vw)` so neither column can collapse or dominate.
- `user-select: none` during drag; listeners cleaned up on `mouseup` and on unmount.
- Desktop-only via a `matchMedia("(min-width: 768px)")` guard — the inline width is only applied on the horizontal layout, so the mobile stacked (`w-full`) layout is untouched and the handle is hidden.
- Width **resets to the 26rem default on reload** (no persistence — deliberate scope decision).

## Tests

- New `AnnotationView.test.tsx`: handle renders, inline width applies on desktop, no inline width on the stacked layout. Passing.
- `npm run lint` clean (only pre-existing `ui/` warnings); `npm run build` compiles.
- Note: 2 failures in `Navigation.test.tsx` are **pre-existing on `main`** and unrelated to this change.

## Other

- Version bump `0.3.0` → `0.3.1` (patch — UI only, no API/behavior change).
- Documented the annotator frontend workflow in `CLAUDE.md` and added an `AGENTS.md` symlink.
- OpenSpec change archived; delta spec synced to `openspec/specs/annotator-layout/spec.md`.
- `frontend/dist` is intentionally **not** committed (gitignored) — CI/publish rebuild it via `npm run build`.