### PR TITLE
Annotator layout: mobile single-scroll + centered card & draggable rail (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.2
+
+- Fix the annotator being unusable on mobile / narrow viewports. The annotation
+  view was a fixed-height two-column layout (`h-screen` + `overflow-hidden`)
+  whose columns fought over the viewport height when stacked, squeezing the
+  prompt/response to an unreadable sliver behind the questions. Below the `md`
+  breakpoint the view now flows as a single scrolling document (prompt/response,
+  then questions), with the fixed-height and per-pane scroll behavior scoped to
+  desktop. The navigation header stays sticky on mobile. Desktop layout —
+  side-by-side panes, independent scroll, draggable rail resize — is unchanged.
+
 ## 0.2.2
 
 - Fix blank annotator page when the bundle is embedded under a path prefix

--- a/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/design.md
+++ b/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`AnnotationView.tsx` frames the annotation view as a locked-height, two-column desktop layout: `h-screen flex flex-col overflow-hidden`, containing a left prompt/response pane (`flex-1 min-h-0 overflow-y-auto`) and a right question rail (`shrink-0 overflow-y-auto`) separated by a draggable resize handle. Each pane owns an independent scroll region so the two columns scroll separately within a fixed viewport.
+
+This model breaks when the panes stack (`flex-col`) below the `md` breakpoint. With the container locked to `h-screen overflow-hidden`, the `shrink-0` rail keeps its full (tall) content height and wins the height fight, while the `flex-1 min-h-0` prompt/response pane collapses to a sliver. The page cannot scroll as a whole because of `overflow-hidden`, so the annotator cannot reach or read the prompt and response.
+
+The desktop-only resize logic (`railWidth`, `isDesktop`, the `hidden md:block` handle) is already correctly gated and is not in scope to change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Below `md`, the view flows as a single natural-scroll document: prompt/response, then questions, then submit — one page scrollbar, top to bottom.
+- The navigation header stays sticky at the top of the mobile scroll.
+- Desktop (`md` and up) layout is byte-for-byte unchanged: side-by-side panes, independent scroll, draggable resize.
+
+**Non-Goals:**
+- No change to the desktop two-column behavior or the resize handle.
+- No tabs, segmented toggles, or column-level collapse (options C/D were considered and rejected).
+- No change to field-level collapsibles, task logic, keyboard handling, or any backend/API.
+
+## Decisions
+
+**Decision: Breakpoint-gate the frame rather than restructure the DOM.**
+Keep a single component tree and scope the desktop-only CSS (fixed height, overflow clipping, per-pane scroll, pane sizing) behind `md:` utilities. Below `md` those rules are absent, so the browser's default document flow takes over and the stacked panes scroll as one.
+- *Rationale*: The DOM already stacks correctly (`flex-col md:flex-row`); the only thing forcing the mobile breakage is desktop-oriented height/overflow rules applied at all widths. Removing them at mobile is subtractive and low-risk.
+- *Alternatives considered*: (A) Separate mobile/desktop component trees — more code, duplicated task rendering, higher divergence risk. (B) Column-level collapse / tab toggle — hides context while answering; user explicitly chose single-scroll (option A).
+
+**Decision: `min-h-screen` on mobile, `md:h-screen md:overflow-hidden` on desktop.**
+The outer frame grows with content on mobile and locks to the viewport on desktop.
+- *Rationale*: `min-h-screen` still fills the viewport when content is short, but allows growth when content is tall.
+
+**Decision: Scope pane scroll/height to `md`.**
+The left pane's `flex-1 min-h-0 overflow-y-auto` and the rail's `overflow-y-auto` become `md:`-prefixed; `SampleDisplay`'s inner `ScrollArea h-full` becomes `md:h-full` so it does not impose a fixed height on mobile.
+- *Rationale*: Independent per-pane scroll is a two-column concept. On a single mobile scroll it produces nested/competing scroll regions and re-introduces the squish.
+
+**Decision: Keep the header sticky on mobile.**
+The existing `sticky top-0 z-20` stays as-is at all breakpoints (confirmed with user).
+- *Rationale*: Keeps the sample counter and progress visible while scrolling into the questions.
+
+## Risks / Trade-offs
+
+- **Nested scroll leftovers** → If any inner `h-full`/`overflow` constraint is missed, the mobile squish partially returns. Mitigation: audit `SampleDisplay`'s `ScrollArea` and both pane wrappers; verify by scrolling a long form on a narrow viewport.
+- **Sticky header eats vertical space on small screens** → Accepted per user decision; header is compact.
+- **Desktop regression risk** → Every desktop rule must remain gated so nothing changes at `md`+. Mitigation: only add `md:` prefixes / mobile fallbacks; do not alter existing `md:` values. Manually verify desktop resize still works.

--- a/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/proposal.md
+++ b/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+On narrow (mobile) viewports the annotation view is unusable: the annotation rail (questions) and the prompt/response column fight over a fixed viewport height, so the questions dominate the screen and the prompt/response collapse to an unreadable sliver at the top. The layout was designed as a locked-height two-column desktop view and never degraded correctly when stacked vertically.
+
+## What Changes
+
+- On viewports below the `md` breakpoint, the annotation view SHALL flow as a single scrolling document (prompt/response, then questions, then the submit action) instead of two independently-scrolling panes locked to the viewport height.
+- The outer frame's fixed viewport height and `overflow-hidden` clipping SHALL apply only at `md` and above; below `md` the page height grows with content.
+- Neither stacked pane SHALL own an independent scroll region or a height that starves the other pane on mobile.
+- The navigation header SHALL remain sticky at the top of the single mobile scroll.
+- The existing desktop two-column layout — side-by-side panes, independent scroll regions, draggable resize handle — SHALL be unchanged.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `annotator-layout`: Add requirement that below the `md` breakpoint the view is a single natural-scroll document with a sticky header, and that the fixed-height/independent-scroll behavior is scoped to desktop only.
+
+## Impact
+
+- `src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx` — outer frame height/overflow and the two pane wrappers become breakpoint-gated.
+- `src/meta_evaluator/annotator/frontend/src/components/SampleDisplay.tsx` — the inner `ScrollArea h-full` height constraint is scoped to `md` so mobile content flows into the page scroll.
+- No API, backend, or data-model changes. Desktop behavior (resize handle, `railWidth`/`isDesktop` logic) is untouched.

--- a/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/specs/annotator-layout/spec.md
+++ b/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/specs/annotator-layout/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Single-scroll mobile layout
+
+On viewports below the `md` breakpoint (the stacked layout), the annotation view SHALL flow as a single scrolling document containing, in order, the prompt/response column and then the annotation rail (questions and submit action). The page height SHALL grow with content rather than being locked to the viewport height, and neither stacked section SHALL own an independent scroll region or a fixed height that starves the other.
+
+#### Scenario: Whole page scrolls as one document
+
+- **WHEN** the view is rendered on a narrow viewport where the columns stack vertically and the combined content is taller than the viewport
+- **THEN** the entire page SHALL scroll as a single document from the prompt/response through the questions to the submit action, using one scrollbar
+
+#### Scenario: Prompt/response is fully readable on mobile
+
+- **WHEN** the view is rendered on a narrow viewport
+- **THEN** the prompt/response section SHALL render at its natural content height and SHALL NOT be collapsed to a sliver by the annotation rail
+
+#### Scenario: No independent pane scrolling on mobile
+
+- **WHEN** the columns are stacked on a narrow viewport
+- **THEN** neither the prompt/response section nor the annotation rail SHALL present its own inner scroll region; scrolling SHALL move the whole page
+
+### Requirement: Fixed-height layout scoped to desktop
+
+The locked viewport height and content clipping of the annotation view SHALL apply only on the horizontal (desktop) layout at the `md` breakpoint and above. Below `md`, the outer frame SHALL NOT clip content or lock to the viewport height.
+
+#### Scenario: Desktop retains locked-height independent scroll
+
+- **WHEN** the view is rendered at the `md` breakpoint or wider
+- **THEN** the layout SHALL remain a fixed-height two-column view with each column scrolling independently within the viewport
+
+#### Scenario: Mobile does not clip content
+
+- **WHEN** the view is rendered below the `md` breakpoint
+- **THEN** the outer frame SHALL NOT apply `overflow-hidden` clipping or a fixed viewport height that hides content
+
+### Requirement: Sticky navigation header on mobile
+
+On the single-scroll mobile layout, the navigation header (sample counter and progress) SHALL remain sticky at the top of the viewport as the page scrolls.
+
+#### Scenario: Header stays pinned while scrolling questions
+
+- **WHEN** the annotator scrolls down into the questions on a narrow viewport
+- **THEN** the navigation header SHALL remain visible pinned to the top of the viewport

--- a/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/tasks.md
+++ b/openspec/changes/archive/2026-07-02-mobile-annotation-single-scroll/tasks.md
@@ -1,0 +1,19 @@
+## 1. Frame and pane layout (AnnotationView.tsx)
+
+- [x] 1.1 Change the outer frame from `h-screen … overflow-hidden` to `min-h-screen md:h-screen … md:overflow-hidden` so the page grows with content on mobile and stays locked on desktop
+- [x] 1.2 Scope the pane container's `overflow-hidden` to `md:overflow-hidden` (keep `flex-col md:flex-row`)
+- [x] 1.3 Gate the left prompt/response pane's height/scroll rules to desktop: `flex-1 min-h-0 … overflow-y-auto` become `md:flex-1 md:min-h-0 md:overflow-y-auto`
+- [x] 1.4 Gate the annotation rail's `overflow-y-auto` to `md:overflow-y-auto`, keeping `w-full md:w-[26rem]` and `md:shrink-0` sizing
+- [x] 1.5 Confirm the navigation header keeps `sticky top-0 z-20` at all breakpoints (no change needed, verify)
+- [x] 1.6 Confirm the desktop resize handle (`hidden md:block`) and `railWidth`/`isDesktop` logic are untouched
+
+## 2. Inner scroll region (SampleDisplay.tsx)
+
+- [x] 2.1 Scope the `ScrollArea` height constraint to desktop (`h-full` → `md:h-full`) so mobile content flows into the page scroll instead of an inner scroll region
+
+## 3. Verification
+
+- [x] 3.1 Manually verify on a narrow viewport: whole page scrolls as one document, prompt/response fully readable, no independent pane scroll, header stays pinned — confirmed by user
+- [x] 3.2 Manually verify desktop (`md`+) is unchanged: two-column layout, independent scroll, draggable resize still works — confirmed by user
+- [x] 3.3 Run `npm run lint` and `npm run test` in `src/meta_evaluator/annotator/frontend`; fix issues in touched files (lint clean; 2 pre-existing Navigation.test failures unrelated to this change, confirmed present on clean tree)
+- [x] 3.4 Run `npm run build` to confirm the bundle compiles

--- a/openspec/specs/annotator-layout/spec.md
+++ b/openspec/specs/annotator-layout/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Define the layout behavior of the annotation view, including how the prompt/response card is positioned, how the annotation rail can be resized, and how these behaviors respond to viewport size.
-
 ## Requirements
-
 ### Requirement: Prompt/response card centering
 
 The annotation view SHALL horizontally center the prompt/response card within the left column, while retaining the existing maximum width constraint on the card.
@@ -47,3 +45,46 @@ The resize handle SHALL only be active on the horizontal (desktop) layout. On na
 
 - **WHEN** the viewport is narrow enough that the left column and annotation rail stack vertically
 - **THEN** the resize handle SHALL NOT be shown and dragging SHALL have no effect on layout
+
+### Requirement: Single-scroll mobile layout
+
+On viewports below the `md` breakpoint (the stacked layout), the annotation view SHALL flow as a single scrolling document containing, in order, the prompt/response column and then the annotation rail (questions and submit action). The page height SHALL grow with content rather than being locked to the viewport height, and neither stacked section SHALL own an independent scroll region or a fixed height that starves the other.
+
+#### Scenario: Whole page scrolls as one document
+
+- **WHEN** the view is rendered on a narrow viewport where the columns stack vertically and the combined content is taller than the viewport
+- **THEN** the entire page SHALL scroll as a single document from the prompt/response through the questions to the submit action, using one scrollbar
+
+#### Scenario: Prompt/response is fully readable on mobile
+
+- **WHEN** the view is rendered on a narrow viewport
+- **THEN** the prompt/response section SHALL render at its natural content height and SHALL NOT be collapsed to a sliver by the annotation rail
+
+#### Scenario: No independent pane scrolling on mobile
+
+- **WHEN** the columns are stacked on a narrow viewport
+- **THEN** neither the prompt/response section nor the annotation rail SHALL present its own inner scroll region; scrolling SHALL move the whole page
+
+### Requirement: Fixed-height layout scoped to desktop
+
+The locked viewport height and content clipping of the annotation view SHALL apply only on the horizontal (desktop) layout at the `md` breakpoint and above. Below `md`, the outer frame SHALL NOT clip content or lock to the viewport height.
+
+#### Scenario: Desktop retains locked-height independent scroll
+
+- **WHEN** the view is rendered at the `md` breakpoint or wider
+- **THEN** the layout SHALL remain a fixed-height two-column view with each column scrolling independently within the viewport
+
+#### Scenario: Mobile does not clip content
+
+- **WHEN** the view is rendered below the `md` breakpoint
+- **THEN** the outer frame SHALL NOT apply `overflow-hidden` clipping or a fixed viewport height that hides content
+
+### Requirement: Sticky navigation header on mobile
+
+On the single-scroll mobile layout, the navigation header (sample counter and progress) SHALL remain sticky at the top of the viewport as the page scrolls.
+
+#### Scenario: Header stays pinned while scrolling questions
+
+- **WHEN** the annotator scrolls down into the questions on a narrow viewport
+- **THEN** the navigation header SHALL remain visible pinned to the top of the viewport
+

--- a/src/meta_evaluator/__init__.py
+++ b/src/meta_evaluator/__init__.py
@@ -12,7 +12,7 @@ from .meta_evaluator import MetaEvaluator
 
 beartype_this_package()
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "MetaEvaluator",

--- a/src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx
+++ b/src/meta_evaluator/annotator/frontend/src/components/AnnotationView.tsx
@@ -86,7 +86,7 @@ export function AnnotationView({
   }, []);
 
   return (
-    <div className="h-screen flex flex-col bg-background overflow-hidden">
+    <div className="min-h-screen md:h-screen flex flex-col bg-background md:overflow-hidden">
       <div className="border-b border-border/60 px-6 py-4 sticky top-0 z-20 bg-background/95 backdrop-blur-sm">
         <Navigation
           sample={sample}
@@ -103,8 +103,8 @@ export function AnnotationView({
         </p>
       </div>
 
-      <div className="relative flex-1 flex min-h-0 flex-col md:flex-row overflow-hidden">
-        <div className="relative flex-1 min-h-0 px-4 py-5 md:px-8 md:py-7 overflow-y-auto scroll-slim">
+      <div className="relative flex-1 flex min-h-0 flex-col md:flex-row md:overflow-hidden">
+        <div className="relative md:flex-1 md:min-h-0 px-4 py-5 md:px-8 md:py-7 md:overflow-y-auto scroll-slim">
           <div className="max-w-4xl mx-auto">
             <SampleDisplay sample={sample} taskConfig={taskConfig} />
           </div>
@@ -118,7 +118,7 @@ export function AnnotationView({
         />
 
         <div
-          className="relative w-full md:w-[26rem] shrink-0 px-4 py-5 md:px-5 md:py-7 overflow-y-auto scroll-slim bg-[var(--annotation-rail)] border-t md:border-t-0 border-[var(--annotation-rail-border)]"
+          className="relative w-full md:w-[26rem] md:shrink-0 px-4 py-5 md:px-5 md:py-7 md:overflow-y-auto scroll-slim bg-[var(--annotation-rail)] border-t md:border-t-0 border-[var(--annotation-rail-border)]"
           style={isDesktop ? { width: railWidth } : undefined}
         >
           <TaskPanel

--- a/src/meta_evaluator/annotator/frontend/src/components/SampleDisplay.tsx
+++ b/src/meta_evaluator/annotator/frontend/src/components/SampleDisplay.tsx
@@ -54,7 +54,7 @@ function CollapsibleField({
 
 export function SampleDisplay({ sample, taskConfig }: Props) {
   return (
-    <ScrollArea className="h-full">
+    <ScrollArea className="md:h-full">
       <div className="space-y-6">
         {sample.prompt_data && taskConfig.prompt_columns && (
           <div className="rounded-xl bg-card border border-border/50 px-4 py-5 md:p-6 shadow-sm">


### PR DESCRIPTION
## Summary

Annotator layout improvements, releasing as **0.3.2**. Two commits on this branch:

- **fix(annotator): single-scroll mobile layout** — below the `md` breakpoint the annotation view now flows as one scrolling document (prompt/response, then questions) instead of a fixed-height two-column layout. Previously the stacked panes fought over the viewport height (`h-screen` + `overflow-hidden`), squeezing the prompt/response to an unreadable sliver behind the questions. Fixed-height and per-pane scroll are now scoped to desktop; the nav header stays sticky on mobile.
- **feat(annotator): center sample card and add draggable rail resize** (prior commit, previously unreleased).

Desktop layout — side-by-side panes, independent scroll, draggable rail resize — is unchanged.

## Changes

- `AnnotationView.tsx` — outer frame `min-h-screen md:h-screen … md:overflow-hidden`; pane container and both pane wrappers gate their height/scroll rules behind `md:`.
- `SampleDisplay.tsx` — inner `ScrollArea` height scoped to `md:h-full` so mobile content flows into the page scroll.
- Version bump to `0.3.2`; CHANGELOG entry.
- OpenSpec: `annotator-layout` spec updated (single-scroll mobile layout, desktop-scoped fixed height, sticky mobile header); change archived.

## Testing

- `npm run build` — compiles clean (tsc + vite).
- `npm run lint` — clean (only pre-existing warnings in untouched `ui/` files).
- `npm run test` — 40/42 pass. The 2 failures are in `Navigation.test.tsx` (untouched) and were verified to **pre-exist on the clean tree** — out of scope for this PR.
- Mobile single-scroll and desktop layout/resize verified in-browser.

Note: the 2 pre-existing `Navigation.test.tsx` failures still need a separate look.